### PR TITLE
Open devices with O_EXCL set

### DIFF
--- a/src/linux/platform_specific.rs
+++ b/src/linux/platform_specific.rs
@@ -10,7 +10,7 @@ use tracing::warn;
 
 pub type IOBuffer = UniqueAlignedBuffer<4096>;
 
-pub const OPEN_FLAGS: i32 = libc::O_DIRECT;
+pub const OPEN_FLAGS: i32 = libc::O_DIRECT | libc::O_EXCL;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ValidDevice {

--- a/src/other_os.rs
+++ b/src/other_os.rs
@@ -7,7 +7,7 @@ use aligned_buffer::UniqueAlignedBuffer;
 
 use crate::Args;
 
-pub const OPEN_FLAGS: i32 = 0;
+pub const OPEN_FLAGS: i32 = libc::O_EXCL;
 
 pub type IOBuffer = UniqueAlignedBuffer<1>;
 


### PR DESCRIPTION
This prevents other processes from attempting r/w accesses on the device. Linux `fdisk` still probably can write to the device but it warns very loudly that it is in use by something else.

Fixes #23 