### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,11 @@ RUN cargo build --release --locked
 
 FROM debian:trixie-slim
 
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    libudev1 \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /app/target/release/disk-spinner /usr/local/bin/disk-spinner
 
 ENTRYPOINT ["/usr/local/bin/disk-spinner"]


### PR DESCRIPTION
This adds a Dockerfile I quickly hacked up to run the tool on my NAS. Helps out with #2.

Usage:

```
docker build --tag disk-spinner .
docker run --rm -it --device /dev/usb1 disk-spinner /dev/usb1
```

I am not aware that the container needs to be granted any additional capabilities.