### PR TITLE
Bump buffer size to 16MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- The default buffer size increased to 16MB (up from 8kB).
+
 ## [[0.2.0](https://docs.rs/disk-spinner/0.2.0/disk-spinner/)] - 2025-08-06
 
 - Initial release on crates.io.

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,11 +56,9 @@ pub(crate) struct Args {
     #[clap(value_parser = clap::value_parser!(ValidDevice), num_args = 1..)]
     devices: Vec<ValidDevice>,
 
-    /// Number of bytes to buffer for writing.
-    ///
-    /// Defaults to the physical block size of the device (or 8192 if that is unset).
-    #[clap(long)]
-    buffer_size: Option<usize>,
+    /// Number of bytes to buffer from the PRNG for writing or reading.
+    #[clap(long, default_value_t = 16*1024*1024)]
+    buffer_size: usize,
 
     #[clap(long, default_value_t, value_parser = clap::value_parser!(GarbageGeneratorVariant))]
     generator: GarbageGeneratorVariant,
@@ -97,13 +95,7 @@ fn main() -> anyhow::Result<()> {
             partition,
             path,
         } = device;
-        let buffer_size = args.buffer_size.unwrap_or_else(|| {
-            device
-                .physical_block_size
-                .unwrap_or(8192)
-                .try_into()
-                .unwrap()
-        });
+        let buffer_size = args.buffer_size;
         sanity_checks(&args, partition, &path, &device)?;
 
         info!(?seed, ?partition, ?device, ?path, "Starting test");

--- a/src/other_os.rs
+++ b/src/other_os.rs
@@ -12,9 +12,7 @@ pub const OPEN_FLAGS: i32 = libc::O_EXCL;
 pub type IOBuffer = UniqueAlignedBuffer<1>;
 
 #[derive(Debug, Clone, Default)]
-pub(crate) struct DeviceMetadata {
-    pub physical_block_size: Option<u64>,
-}
+pub(crate) struct DeviceMetadata {}
 
 #[derive(Debug, Clone)]
 pub(crate) struct ValidDevice {


### PR DESCRIPTION
8kB (or whatever the physical block size is) was way too small in O_DIRECT mode, and leads to very slow writes. With 16MB, we can saturate the drive at ~all times.

Fixes #44 